### PR TITLE
Fix missing metadata header.

### DIFF
--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -195,8 +195,6 @@ generate_results_csv()
 			else
 				output=`echo $value | sed "s/ /:/g"`
 			fi
-
-
 			echo $output >> ../$out_file
 		done < "data"
 		grep -qi error ../$out_file

--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -165,7 +165,6 @@ generate_results_csv()
 	mkdir work_around 2> /dev/null
 	for file in `ls *txt`; do
 		out_file=`echo $file | cut -d'.' -f1-4`.results.csv
-		$TOOLS_BIN/test_header_info --front_matter --results_file "../$out_file" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $version --test_name $test_name
 		start_data=0
 		#
 		# For some reason we read the wrong file if we try addressing
@@ -174,7 +173,8 @@ generate_results_csv()
 		#
 		cp $file work_around/data
 		cd work_around
-		echo "Benchmarks:Base copies:Base Run Time:Base Rate" > ../$out_file
+		$TOOLS_BIN/test_header_info --front_matter --results_file "../$out_file" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $version --test_name $test_name
+		echo "Benchmarks:Base copies:Base Run Time:Base Rate" >> ../$out_file
 		while IFS= read -r line
 		do
 			if [ $start_data -eq 0 ]; then
@@ -195,6 +195,8 @@ generate_results_csv()
 			else
 				output=`echo $value | sed "s/ /:/g"`
 			fi
+
+
 			echo $output >> ../$out_file
 		done < "data"
 		grep -qi error ../$out_file
@@ -232,7 +234,7 @@ done
 # clone the repo.
 #
 if [ ! -d "test_tools" ]; then
-	git clone $tools_git ${curdir}/test_tools
+	git clone $tools_git test_tools
 	if [ $? -ne 0 ]; then
 		exit_out "Error: pulling git $tools_git failed." 1
 	fi

--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -109,7 +109,7 @@ usage()
 	echo "  --speccpu_run_dir <dir>: If provided where the kit is installed at"
 	echo "  --uploads <path>: location to find the iso file in".
 	echo "  --no_disk: use the filesystem with the most free space to install speccpu on."
-	source test_tools/general_setup --usage
+	source ${curdir}/test_tools/general_setup --usage
 }
 
 if [ $give_usage -eq 1 ]; then 
@@ -232,7 +232,7 @@ done
 # clone the repo.
 #
 if [ ! -d "test_tools" ]; then
-	git clone $tools_git test_tools
+	git clone $tools_git ${curdir}/test_tools
 	if [ $? -ne 0 ]; then
 		exit_out "Error: pulling git $tools_git failed." 1
 	fi
@@ -257,7 +257,7 @@ fi
 # to_tuned_setting: tuned setting
 #
 
-source test_tools/general_setup "$@"
+source ${curdir}/test_tools/general_setup "$@"
 
 # Define options
 #


### PR DESCRIPTION
# Description
It places the system metadata in the csv results file, currently missing

# Before/After Comparison
Before change:
Benchmarks:Base copies:Base Run Time:Base Rate
500.perlbench_r:4:475:13.4
502.gcc_r:4:346:16.4
505.mcf_r:4:396:16.3
520.omnetpp_r:4:668:7.85

After change
\# Test general meta start
\# Test: speccpu2017
\# Results version: 118
\# Host: m6a.xlarge
\# Sys environ: aws
\# Tuned: virtual-guest
\# OS: 5.14.0-362.18.1.el9_3.x86_64
\# Numa nodes: 1
\# CPU family: AMD EPYC 7R13 Processor
\# Number cpus: 4
\# Memory: 15720220kB
\# Test general meta end
Benchmarks:Base copies:Base Run Time:Base Rate
500.perlbench_r:4:475:13.4
502.gcc_r:4:346:16.4
505.mcf_r:4:396:16.3
520.omnetpp_r:4:668:7.85


# Clerical Stuff
This closes Issue #29 


Relates to JIRA: RPOPC-344
