### PR TITLE
Add workaround for perlbench with newer gcc

### DIFF
--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -509,6 +509,10 @@ else
 		sed "s/   preENV_LD_LIBRARY_PATH/#   preENV_LD_LIBRARY_PATH/g" /tmp/foo1 > /tmp/foo2
 		# Temporary compiler flag workaround for build error in cam4 with gcc14
 		sed '/527.cam4_r,627.cam4_s:/!b;n; s/PORTABILITY   = -DSPEC_CASE_FLAG/PORTABILITY   = -DSPEC_CASE_FLAG -Wno-error=implicit-int/' /tmp/foo2 > $spec_config
+		LNNO=$(cat -n /tmp/foo2 | grep -A 20 '^ .*500.perlbench' | grep PORT | head -1 | awk '{print $1}')
+
+		sed "${LNNO}s/\$/ -Wno-incompatible-pointer-types/" /tmp/foo2 > $spec_config
+
 	fi
 
 	cd ${speccpu_run}


### PR DESCRIPTION
# Description
Newer gcc versions switched C standards which made some warnings into errors; this breaks perlbench, so until SPEC fixes the kit, disable the warning entirely.
 
# Before/After Comparison
Before this fix, the build step will fail to build perlbench, after the fix all benchmarks build cleanly.  NOTE: the wrapper will still output a result because SPECcpu doesn't consider this build error to be fatal and doesn't set an error code.

# Clerical Stuff

Relates to JIRA: RPOPC-489
