### PR TITLE
Fix duplicate entries

### DIFF
--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -176,7 +176,7 @@ generate_results_csv()
 	stat_time="${2}"
 	end_time="${3}"
 	mkdir work_around 2> /dev/null
-	for file in `ls *txt`; do
+	for file in `ls -rt *txt | tail -1`; do
 		if [[ -f recorded ]]; then
 			grep -q $1 recorded
 			if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
# Description
Corrects getting duplicate entries.

# Before/After Comparison
Before: When intrate,fprate where designated as tests, we would get duplicate entries in the intrate final csv
After: We now get 1 set of results in intrate final csv when running intrate,fprate.

# Clerical Stuff
This closes #43 

Relates to JIRA: RPOPC-842

Testing
Command executed
/home/ec2-user/workloads/speccpu2017-wrapper-2.2/speccpu2017/run_speccpu --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.2xlarge" --sysname "m7i.2xlarge" --sys_type aws  --use_pcp --disks grab_disks --test intrate,fprate --debug

csv file
Benchmarks,Base copies,Base Run Time,Base Rate,Start_Date,End_Date
500.perlbench_r,8,435,29.3,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
502.gcc_r,8,343,33.0,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
505.mcf_r,8,497,26.0,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
520.omnetpp_r,8,654,16.0,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
523.xalancbmk_r,8,363,23.2,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
525.x264_r,8,283,49.5,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
531.deepsjeng_r,8,408,22.5,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
541.leela_r,8,570,23.3,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
548.exchange2_r,8,431,48.6,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z
557.xz_r,8,546,15.8,2026-02-23T19:14:59Z,2026-02-23T20:31:33Z

debug option output
[speccpu_debug.txt](https://github.com/user-attachments/files/25515907/speccpu_debug.txt)

