### PR TITLE
Add test_validation to speccpu2017 results

### DIFF
--- a/speccpu2017/results_schema.py
+++ b/speccpu2017/results_schema.py
@@ -1,0 +1,37 @@
+import pydantic
+import datetime
+
+from enum import Enum
+
+class Benchmark(Enum):
+    SPEC_500_perlbench_r = "500.perlbench_r"
+    SPEC_502_gcc_r = "502.gcc_r"
+    SPEC_505_mcf_r = "505.mcf_r"
+    SPEC_520_omnetpp_r = "520.omnetpp_r"
+    SPEC_523_xalancbmk_r = "523.xalancbmk_r"
+    SPEC_525_x264_r = "525.x264_r"
+    SPEC_531_deepsjeng_r = "531.deepsjeng_r"
+    SPEC_541_leela_r = "541.leela_r"
+    SPEC_548_exchange2_r = "548.exchange2_r"
+    SPEC_557_xz_r = "557.xz_r"
+    SPEC_503_bwaves_r = "503.bwaves_r"
+    SPEC_507_cactuBSSN_r = "507.cactuBSSN_r"
+    SPEC_508_namd_r = "508.namd_r"
+    SPEC_510_parest_r = "510.parest_r"
+    SPEC_511_povray_r = "511.povray_r"
+    SPEC_519_lbm_r = "519.lbm_r"
+    SPEC_521_wrf_r = "521.wrf_r"
+    SPEC_526_blender_r = "526.blender_r"
+    SPEC_527_cam4_r = "527.cam4_r"
+    SPEC_538_imagick_r = "538.imagick_r"
+    SPEC_544_nab_r = "544.nab_r"
+    SPEC_549_fotonik3d_r = "549.fotonik3d_r"
+    SPEC_554_roms_r = "554.roms_r"
+
+class Speccput2017_Results (pydantic.BaseModel):
+    Benchmarks: Benchmark
+    Base_copies: int = pydantic.Field(gt=0)
+    Base_Run_Time: int = pydantic.Field(gt=0)
+    Base_Rate: float = pydantic.Field(gt=0, allow_inf_nan=False)
+    Start_Date: datetime.datetime
+    End_Date: datetime.datetime

--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -39,8 +39,24 @@ give_usage=0
 use_fs=""
 run_loc_selected=0
 data_disk_fs="xfs"
-
 disk_options=""
+test_rtc=0
+script_dir=$(realpath $(dirname $0))
+
+#
+# Check to see if the test tools directory exists.  If it does, we do not need to
+# clone the repo.
+#
+tools_git="https://github.com/redhat-performance/test_tools-wrappers"
+TOOLS_BIN=${HOME}/test_tools
+export TOOLS_BIN
+if [ ! -d "${TOOLS_BIN}" ]; then
+	git clone $tools_git ${TOOLS_BIN}
+	if [ $? -ne 0 ]; then
+		exit_out "Error: pulling git $tools_git failed." 1
+	fi
+fi
+
 provide_disks()
 {
 	echo You need to designate disks, following are currently not mounted.
@@ -120,7 +136,7 @@ usage()
 	echo "  --test <list>: A comma separated list.  You may specify intrate, fprate, or any subtest (ie 500.perlbench_r)."
 	echo "  --uploads <path>: location to find the iso file in".
 	echo "  --no_disk: use the filesystem with the most free space to install speccpu on."
-	source ${curdir}/test_tools/general_setup --usage
+	source ${TOOLS_BIN}/general_setup --usage
 }
 
 if [ $give_usage -eq 1 ]; then 
@@ -138,7 +154,7 @@ if [ ! -f "/tmp/${test_name}".out ]; then
 	command="${0} $@ $disk_options"
 	echo $command
 	$command &> /tmp/${test_name}.out
-	exit 0
+	exit $?
 fi
 
 setup_done=0
@@ -147,7 +163,6 @@ out_file=""
 copies=""
 tests="fprate,intrate"
 test_prefix="none"
-tools_git="https://github.com/redhat-performance/test_tools-wrappers"
 disk_to_use=""
 spec_config=""
 
@@ -173,9 +188,11 @@ fi
 
 generate_results_csv()
 {
+	test_ran="${1}"
 	stat_time="${2}"
 	end_time="${3}"
 	mkdir work_around 2> /dev/null
+	out_file=""
 	for file in `ls -rt *txt | tail -1`; do
 		if [[ -f recorded ]]; then
 			grep -q $1 recorded
@@ -192,7 +209,7 @@ generate_results_csv()
 		#
 		cp $file work_around/data
 		cd work_around
-		$TOOLS_BIN/test_header_info --front_matter --results_file "../$out_file" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $version --test_name $test_name --field_header "Benchmarks,Base copies,Base Run Time,Base Rate"
+		$TOOLS_BIN/test_header_info --front_matter --results_file "../$out_file" --host $to_configuration --sys_type $to_sys_type --tuned $to_tuned_setting --results_version $version --test_name $test_name --field_header "Benchmarks,Base_copies,Base_Run_Time,Base_Rate"
 		pwd
 		while IFS= read -r line
 		do
@@ -210,7 +227,7 @@ generate_results_csv()
 			if [[ $checking == "NR" ]]; then
 				run_status="Failed NR found in the results"
 				local_test_name=`echo $value | cut -d' ' -f 1`
-				output=$(build_data_string "${local_test_name}" "" "" "" "NR" "${start_time}" "${end_time}")
+				output=$(build_data_string "${local_test_name}" "" "" "NR" "${start_time}" "${end_time}")
 			else
 				f1=`echo $value | cut -d' ' -f1`
 				f2=`echo $value | cut -d' ' -f2`
@@ -228,19 +245,38 @@ generate_results_csv()
 			fi
 			echo $output >> ../$out_file
 		done < "data"
-		grep -qi error ../$out_file
-		if [ $? -eq 0 ]; then
-			run_status="Failed: error detected"
-		fi
 		cd ..
 	done
 	if [[ $to_use_pcp -eq 1 ]]; then
 		results2pcp_add_value_commit
 		reset_pcp_om
 	fi
-	rm -rf work_around
+	#
+	# Only check the tests we actually were suppose to run.
+	#
+	verify_file=$(mktemp /tmp/speccpu_test_verify.XXXXX)
+	if [[ $test_ran != "intrate" ]] && [[ $test_ran != "fprate" ]]; then
+		cp -R $out_file $verify_file
+		grep Benchmark $out_file > $verify_file
+		grep $test_ran $out_file >> $verify_file
+	else
+		cp -R $out_file $verify_file
+	fi 
+	rm -f speccpu_res.json
+	${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $verify_file --output_file speccpu_res.json
+	if [[ $? -ne 0 ]]; then
+		exit_out "${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $out_File --output_file speccpu_res.json returned an an error" 3
+	fi
+	${TOOLS_BIN}/verify_results $to_verify_flags --schema_file $script_dir/results_schema.py --class_name Speccput2017_Results --file speccpu_res.json
+	#
+	# Induce error
+	#
+	if [[ $? -ne 0 ]]; then
+		echo Test failure detected: $out_File
+		test_rtc=3
+	fi
+	rm -rf work_around $verify_file
 }
-
 found=0
 show_usage=0
 for arg in "$@"; do
@@ -262,17 +298,6 @@ for arg in "$@"; do
 	fi
 done
 
-#
-# Check to see if the test tools directory exists.  If it does, we do not need to
-# clone the repo.
-#
-if [ ! -d "test_tools" ]; then
-	git clone $tools_git ${curdir}/test_tools
-	if [ $? -ne 0 ]; then
-		exit_out "Error: pulling git $tools_git failed." 1
-	fi
-fi
-
 if [ $show_usage -eq 1 ]; then
 	usage $0
 fi
@@ -290,7 +315,7 @@ fi
 # to_tuned_setting: tuned setting
 #
 
-source ${curdir}/test_tools/general_setup "$@"
+source ${TOOLS_BIN}/general_setup "$@"
 
 ${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/speccpu2017.json --no_packages $to_no_pkg_install
 if [[ $? -ne 0 ]]; then
@@ -597,11 +622,12 @@ mkdir -p ${RESULTSDIR}/result
 cp -R ${speccpu_run}/result ${RESULTSDIR}
 mv /tmp/${test_name}.out ${RESULTSDIR}
 echo $run_status >> ${RESULTSDIR}/test_results_report
+echo RESULTSDIR $RESULTSDIR
 working_dir=`ls -rtd /tmp/results*${test_name}* | grep -v tar | tail -1`
 tar hcf results_${test_name}_${to_tuned_setting}.tar  $RESULTSDIR
-${curdir}/test_tools/save_results --curdir $curdir --home_root $to_home_root --tar_file /tmp/results_${test_name}_${to_tuned_setting}.tar --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user $cpdir
+${TOOLS_BIN}/save_results --curdir $curdir --home_root $to_home_root --tar_file /tmp/results_${test_name}_${to_tuned_setting}.tar --test_name $test_name --tuned_setting=$to_tuned_setting --version NONE --user $to_user $cpdir
 #
 # Remove speccpu temp files.
 #
 rm /tmp/default_spec.cfg.*
-exit_out "Test completed" 0
+exit_out "Test completed" $test_rtc

--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -268,15 +268,13 @@ generate_results_csv()
 		exit_out "${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $out_File --output_file speccpu_res.json returned an an error" 3
 	fi
 	${TOOLS_BIN}/verify_results $to_verify_flags --schema_file $script_dir/results_schema.py --class_name Speccput2017_Results --file speccpu_res.json
-	#
-	# Induce error
-	#
 	if [[ $? -ne 0 ]]; then
 		echo Test failure detected: $out_File
 		test_rtc=3
 	fi
 	rm -rf work_around $verify_file
 }
+
 found=0
 show_usage=0
 for arg in "$@"; do

--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -53,9 +53,10 @@ export TOOLS_BIN
 if [ ! -d "${TOOLS_BIN}" ]; then
 	git clone $tools_git ${TOOLS_BIN}
 	if [ $? -ne 0 ]; then
-		exit_out "Error: pulling git $tools_git failed." 1
+		exit_out "Error: pulling git $tools_git failed." $E_GENERAL
 	fi
 fi
+source ${TOOLS_BIN}/error_codes
 
 provide_disks()
 {
@@ -264,13 +265,14 @@ generate_results_csv()
 	fi 
 	rm -f speccpu_res.json
 	${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $verify_file --output_file speccpu_res.json
-	if [[ $? -ne 0 ]]; then
-		exit_out "${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $out_File --output_file speccpu_res.json returned an an error" 3
+	test_rtc=$?
+	if [[ $test_rtc -ne 0 ]]; then
+		exit_out "${TOOLS_BIN}/csv_to_json $to_json_flags --csv_file $out_File --output_file speccpu_res.json returned an an error" $test_rtc
 	fi
 	${TOOLS_BIN}/verify_results $to_verify_flags --schema_file $script_dir/results_schema.py --class_name Speccput2017_Results --file speccpu_res.json
-	if [[ $? -ne 0 ]]; then
+	test_rtc=$?
+	if [[ $test_rtc -ne 0 ]]; then
 		echo Test failure detected: $out_File
-		test_rtc=3
 	fi
 	rm -rf work_around $verify_file
 }
@@ -315,10 +317,10 @@ fi
 
 source ${TOOLS_BIN}/general_setup "$@"
 
-${TOOLS_BIN}/package_tool --wrapper_config ${run_dir}/speccpu2017.json --no_packages $to_no_pkg_install
+package_tool --wrapper_config ${run_dir}/speccpu2017.json --no_packages $to_no_pkg_install
 if [[ $? -ne 0 ]]; then
 	echo Package installation using ${TOOLS_BIN}/package_tool was unsuccessful.
-	exit 1
+	exit $E_PACKAGE_TOOL_PACKAGING
 fi
 
 # Define options
@@ -363,7 +365,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--disks)
 			if [ $run_loc_selected -ne 0 ]; then
-				exit_out "Error: --disks run location already designated, cannot designate multiple"
+				exit_out "Error: --disks run location already designated, cannot designate multiple" $E_USAGE
 			fi
 			run_loc_selected=1
 			disk_to_use=${2}
@@ -395,7 +397,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--speccpu_run_dir)
 			if [ $run_loc_selected -ne 0 ]; then
-				exit_out "Error: --speccpu_run_dir run location already designated, cannot designate multiple"
+				exit_out "Error: --speccpu_run_dir run location already designated, cannot designate multiple" $E_USAGE
 			fi
 			run_loc_selected=1
 			speccpu_run=${2}
@@ -404,7 +406,7 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--no_disk)
 			if [ $run_loc_selected -ne 0 ]; then
-				exit_out "Error: --no_disk run location already designated, cannot designate multiple"
+				exit_out "Error: --no_disk run location already designated, cannot designate multiple" $E_USAGE
 			fi
 			run_loc_selected=1
 			use_fs=`df --output=avail,target,source | grep -v Mounted | grep -v tmpfs | sort -n | tail -1 | xargs | sed "s/ /:/g" | cut -d: -f2`
@@ -451,7 +453,7 @@ if [ $installed -eq 0 ] && [[ $disk_to_use != "grab_disks" ]] && [[ $speccpu_run
 		value=`file $item`
 		echo $value | grep "block special" > /dev/null
 		if [ $? -ne 0 ]; then
-			exit_out "Error: $item is not a block device" 1
+			exit_out "Error: $item is not a block device" $E_GENERAL
 		fi
 	done
 fi
@@ -482,7 +484,7 @@ if [[ ! -f "${speccpu_iso_mnt}/shrc" ]]; then
 	echo mount  -t iso9660 $speccpu_iso_file ${speccpu_iso_mnt}
 	mount  -t iso9660 $speccpu_iso_file ${speccpu_iso_mnt}
 	if [ $? -ne 0 ]; then
-		exit_out "Error: failed to mount $speccpu_iso_file ${speccpu_iso_mnt}" 1
+		exit_out "Error: failed to mount $speccpu_iso_file ${speccpu_iso_mnt}" $E_GENERAL
 	fi
 fi
 if [[ $speccpu_run_dir == "" ]]; then
@@ -496,7 +498,7 @@ if [[ $speccpu_run_dir == "" ]]; then
 	wipefs -a /dev/${disk}
 	mkfs.$data_disk_fs /dev/${disk}
 	if [ $? -ne 0 ]; then
-		exit_out "Error: Failed to make filesystem using /dev/${disk}" 1
+		exit_out "Error: Failed to make filesystem using /dev/${disk}" $E_GENERAL
 	fi
 	if [[ ! -d ${speccpu_run} ]]; then
 		mkdir ${speccpu_run}
@@ -504,7 +506,7 @@ if [[ $speccpu_run_dir == "" ]]; then
 	echo mount /dev/${disk} ${speccpu_run}
 	mount /dev/${disk} ${speccpu_run}
 	if [ $? -ne 0 ]; then
-		exit_out "Error: failed to mount /dev/${disk} on to ${speccpu_run}" 1
+		exit_out "Error: failed to mount /dev/${disk} on to ${speccpu_run}" $E_GENERAL
 	fi
 	rm -rf ${speccpu_run}
 	mkdir ${speccpu_run}
@@ -516,7 +518,7 @@ echo yes >> /tmp/options
 cd ${speccpu_iso_mnt}
 ./install.sh < /tmp/options
 if [ $? -ne 0 ]; then
-	exit_out  "Error: install.sh failed." 1
+	exit_out  "Error: install.sh failed." $E_GENERAL
 fi
 echo install complete
 #
@@ -524,7 +526,7 @@ echo install complete
 #
 version=`cat ${speccpu_iso_mnt}/version.txt | sed "s/\.//g"`
 if [[ $version -lt 118 ]]; then
-	exit_out "Error, need version 1.1.8 or later" 1
+	exit_out "Error, need version 1.1.8 or later" $E_GENERAL
 fi
 sed "s/%   define  gcc_dir        \"\/opt\/rh\/devtoolset-9\/root\/usr\"/%   define  gcc_dir \/usr/g" $spec_config > /tmp/foo
 sed "s/tune                 = base,peak/tune                 = base/g" /tmp/foo > /tmp/foo1


### PR DESCRIPTION
# Description
Adds code to verify the reported are results are at least reasonable.

# Before/After Comparison
Before:  Test failures would not be reported.
After: If the results are not valid, it will be flagged.

# Clerical Stuff
This closes #42 

Relates to JIRA: RPOPC-824

Testing
Command executed
/home/ec2-user/workloads/speccpu2017-wrapper/speccpu2017/run_speccpu --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.2xlarge" --sysname "m7i.2xlarge" --sys_type aws  --use_pcp --disks grab_disks --test intrate,fprate --debug

Single test: passes
runcpu finished at 2026-02-27 16:38:34; 425 total seconds elapsed
/speccpu_run/result /speccpu_run
/speccpu_run/result/work_around
PCP metrics reset
Results verified
Stopping PCP subset
RESULTSDIR results_speccpu_virtual-guest_2026.02.27-16.38.44
updating: results_speccpu2017_virtual-guest.tar (deflated 80%)
Test completed
[root@ip-170-0-26-3 ec2-user]# echo $?
0

Single test: failure induced
./speccpu2017.cmd 
/home/ec2-user/workloads/speccpu2017-wrapper-2.2/speccpu2017/run_speccpu --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config m7i.2xlarge --sysname m7i.2xlarge --sys_type aws --use_pcp --disks grab_disks --test 500.perlbench_r
[root@ip-170-0-26-3 ec2-user]# echo $?
3

--debug file
[speccpu2017.txt](https://github.com/user-attachments/files/25608895/speccpu2017.txt)

