### PR TITLE
New test_tools loading

### DIFF
--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -50,12 +50,45 @@ script_dir=$(realpath $(dirname $0))
 tools_git="https://github.com/redhat-performance/test_tools-wrappers"
 TOOLS_BIN=${HOME}/test_tools
 export TOOLS_BIN
-if [ ! -d "${TOOLS_BIN}" ]; then
-	git clone $tools_git ${TOOLS_BIN}
-	if [ $? -ne 0 ]; then
-		exit_out "Error: pulling git $tools_git failed." $E_GENERAL
-	fi
-fi
+
+attempt_tools_wget()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                wget ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attetmpt_tools_curl()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                curl -L -O ${tools_git}/archive/refs/heads/main.zip
+                if [[ $? -eq 0 ]]; then
+                        unzip -q main.zip
+                        mv test_tools-wrappers-main ${TOOLS_BIN}
+                        rm main.zip
+                fi
+        fi
+}
+
+attempt_tools_git()
+{
+        if [[ ! -d "$TOOLS_BIN" ]]; then
+                git clone $tools_git "$TOOLS_BIN"
+                if [ $? -ne 0 ]; then
+                        exit_out "Error: pulling git $tools_git failed." 101
+                fi
+        fi
+}
+
+attempt_tools_wget
+attetmpt_tools_curl
+attempt_tools_git
+
 source ${TOOLS_BIN}/error_codes
 
 provide_disks()

--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -63,7 +63,7 @@ attempt_tools_wget()
         fi
 }
 
-attetmpt_tools_curl()
+attempt_tools_curl()
 {
         if [[ ! -d "$TOOLS_BIN" ]]; then
                 curl -L -O ${tools_git}/archive/refs/heads/main.zip
@@ -86,7 +86,7 @@ attempt_tools_git()
 }
 
 attempt_tools_wget
-attetmpt_tools_curl
+attempt_tools_curl
 attempt_tools_git
 
 source ${TOOLS_BIN}/error_codes


### PR DESCRIPTION
# Description
When loading test_tools-wrappers in we will try curl, wget and git before failing

# Before/After Comparison
Before:  Seeing failures of loading test_tools-wrappers using git, because git is not present.
After: Now try ,curl, wget and git before failing.

# Clerical Stuff
This closes #46 
to close the issue out automatically.


Relates to JIRA: RPOPC-869

Testing Done

Used scenario file
global:
  ssh_key_file: replace_your_ssh_key
  terminate_cloud: 1
  os_vendor: rhel
  results_prefix: speccpu_results
  os_vendor: rhel
  system_type: aws
  cloud_os_id: ami-035032ea878eca201
systems:
  system1:
    tests: "speccpu2017"
    host_config: "m7i.2xlarge:Disks;type=gp3;throughput=1000;disk_iops=16000;size=3000;number=2"

csv file
Benchmarks,Base_copies,Base_Run_Time,Base_Rate,Start_Date,End_Date
500.perlbench_r,8,388,32.8,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
502.gcc_r,8,319,35.5,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
505.mcf_r,8,453,28.5,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
520.omnetpp_r,8,595,17.6,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
523.xalancbmk_r,8,331,25.5,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
525.x264_r,8,260,53.8,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
531.deepsjeng_r,8,377,24.3,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
541.leela_r,8,522,25.4,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
548.exchange2_r,8,388,54.1,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z
557.xz_r,8,467,18.5,2026-03-13T12:23:14Z,2026-03-13T13:32:32Z

Test returned 0 and produced results.