### PR TITLE
dereference symlink to block devices

### DIFF
--- a/speccpu2017/run_speccpu
+++ b/speccpu2017/run_speccpu
@@ -472,7 +472,8 @@ done
 if [ $installed -eq 0 ] && [[ $disk_to_use != "grab_disks" ]] && [[ $speccpu_run_dir == "" ]]; then
 	device_list=`echo $disk_to_use | sed "s/,/ /g"`
 	for item in $device_list; do
-		value=`file $item`
+		#dereference symlinks to handle things like multipath aliases in /dev/mapper
+		value=`file -L $item`
 		echo $value | grep "block special" > /dev/null
 		if [ $? -ne 0 ]; then
 			exit_out "Error: $item is not a block device" $E_GENERAL


### PR DESCRIPTION
# Description
This adds "-L" to the "file" command used to validate the selection of a block device. This will allow symlinks to be dereferenced so things like /dev/mapper/msa1 or /dev/disk/by-id/nvme-Dell-yadayadayada will be recognized as block devices

See also https://github.com/redhat-performance/fio-wrapper/pull/33

# Before/After Comparison
Before: If a file which is a symlink to a block device is provided, the validation sees a symlink instead of a blockdev and fails out:
Error: /dev/disk/by-id/nvme-Dell_Ent_NVMe_P5600_MU_U.2_1.6TB_PHAB115400GQ1P9SGN is not a block device

After: If a file which is a symlink to a block device is provided, the validation the validation follows the link:
Log excerpt:
/dev/disk/by-id/nvme-Dell_Ent_NVMe_P5600_MU_U.2_1.6TB_PHAB115400GQ1P9SGN,/dev/disk/by-id/nvme-Dell_Ent_NVMe_P5600_MU_U.2_1.6TB_PHAB115400H91P9SGN,/dev/disk/by-i
d/nvme-Dell_Ent_NVMe_P5600_MU_U.2_1.6TB_PHAB1341012P1P9SGN,/dev/disk/by-id/nvme-Dell_Ent_NVMe_P5600_MU_U.2_1.6TB_PHAB201000ES1P9SGN^M
/dev/disk/by-id/nvme-Dell_Ent_NVMe_P5600_MU_U.2_1.6TB_PHAB115400GQ1P9SGN: 8 bytes were erased at offset 0x00000218 (LVM2_member): 4c 56 4d 32 20 30 30 31^M
meta-data=/dev/disk/by-id/nvme-Dell_Ent_NVMe_P5600_MU_U.2_1.6TB_PHAB115400GQ1P9S
GN isize=512    agcount=128, agsize=3052370 blks^M
         =                       sectsz=512   attr=2, projid32bit=1^M
         =                       crc=1        finobt=1, sparse=1, rmapbt=1^M
         =                       reflink=1    bigtime=1 inobtcount=1 nrext64=1^M
         =                       exchange=0   metadir=0^M
data     =                       bsize=4096   blocks=390703360, imaxpct=5^M
         =                       sunit=0      swidth=0 blks^M
naming   =version 2              bsize=4096   ascii-ci=0, ftype=1, parent=0^M
log      =internal log           bsize=4096   blocks=205200, version=2^M


# Clerical Stuff
This closes #53 
Relates to JIRA: RPOPC-1292
[speccpu.log](https://github.com/user-attachments/files/28906221/speccpu.log) Full output
